### PR TITLE
Let providers specify their name to cause less confusion

### DIFF
--- a/js/view/settings.vue
+++ b/js/view/settings.vue
@@ -1,14 +1,18 @@
 <template>
 	<div class="section">
 		<h2 data-anchor-name="sms-second-factor-auth">
-			<l10n text="SMS second-factor auth"></l10n>
+			<l10n text="Message gateway second-factor auth"></l10n>
 		</h2>
 		<div v-if="loading">
 			<span class="icon-loading-small"></span>
 		</div>
 		<div v-else>
+			<p>
+				<l10n text="Here you can configure the message gateway to receive two-factor authentication codes via {gateway}."
+					  v-bind:options="{gateway: gatewayName}"></l10n>
+			</p>
 			<p v-if="state === 0">
-				<l10n text="You are not using SMS-based two-factor authentication at the moment"></l10n>
+				<l10n text="You are not using gateway for two-factor authentication at the moment."></l10n>
 				<button @click="enable">
 					<l10n text="Enable"></l10n>
 				</button>
@@ -24,15 +28,16 @@
 				</button>
 			</p>
 			<p v-if="state === 2">
-				<l10n text="A confirmation code has been sent to {phone}. Please check your phone and insert the code here:"
-					  v-bind:options="{phone: phoneNumber}"></l10n>
+				<l10n text="A confirmation code has been sent to {phone} via {gateway}. Please insert the code here:"
+					  v-bind:options="{gateway: gatewayName, phone: phoneNumber}"></l10n>
 				<input v-model="confirmationCode">
 				<button @click="confirm">
 					<l10n text="Confirm"></l10n>
 				</button>
 			</p>
 			<p v-if="state === 3">
-				<l10n text="SMS-based two-factor authentication is enabled for your account."></l10n>
+				<l10n text="Your account was successfully configured to receive messages via {gateway}."
+					  v-bind:options="{gateway: gatewayName}"></l10n>
 				<button @click="disable">
 					<l10n text="Disable"></l10n>
 				</button>
@@ -58,12 +63,14 @@
 				phoneNumber: '',
 				confirmationCode: '',
 				identifier: '',
+				gatewayName: '',
 				verificationError: false
 			};
 		},
 		mounted: function () {
 			getState()
 				.then(res => {
+					this.gatewayName = res.gatewayName;
 					this.state = res.state;
 					this.phoneNumber = res.phoneNumber;
 					this.loading = false;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,7 +24,7 @@ declare(strict_types = 1);
 namespace OCA\TwoFactorGateway\AppInfo;
 
 use Exception;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCA\TwoFactorGateway\Service\Gateway\PlaySMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\TelegramGateway;
@@ -46,7 +46,7 @@ class Application extends App {
 		$config = $container->query(IConfig::class);
 		$provider = $config->getAppValue('twofactor_gateway', 'sms_provider', 'websms.de');
 
-		$container->registerAlias(ISmsService::class, $this->getSmsProviderClass($provider));
+		$container->registerAlias(IGateway::class, $this->getSmsProviderClass($provider));
 	}
 
 	private function getSmsProviderClass(string $name): string {

--- a/lib/Provider/SmsProvider.php
+++ b/lib/Provider/SmsProvider.php
@@ -25,7 +25,7 @@ namespace OCA\TwoFactorGateway\Provider;
 
 use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
 use OCA\TwoFactorGateway\PhoneNumberMask;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCA\TwoFactorGateway\Service\SetupService;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\IConfig;
@@ -43,7 +43,7 @@ class SmsProvider implements IProvider {
 	const STATE_ENABLED = 3;
 	const SESSION_KEY = 'twofactor_gateway_secret';
 
-	/** @var ISmsService */
+	/** @var IGateway */
 	private $smsService;
 
 	/** @var SetupService */
@@ -61,7 +61,7 @@ class SmsProvider implements IProvider {
 	/** @var IL10N */
 	private $l10n;
 
-	public function __construct(ISmsService $smsService, SetupService $setupService, ISession $session,
+	public function __construct(IGateway $smsService, SetupService $setupService, ISession $session,
 								ISecureRandom $secureRandom, IConfig $config, IL10N $l10n) {
 		$this->smsService = $smsService;
 		$this->setupService = $setupService;

--- a/lib/Provider/State.php
+++ b/lib/Provider/State.php
@@ -28,19 +28,24 @@ use JsonSerializable;
 
 class State implements JsonSerializable {
 
+	/** @var string */
+	private $gatewayName;
+
 	/** @var int */
 	private $state;
 
 	/** @var string */
 	private $phoneNumber;
 
-	public function __construct(int $state, string $phoneNumber = null) {
+	public function __construct(string $gatewayName, int $state, string $phoneNumber = null) {
+		$this->gatewayName = $gatewayName;
 		$this->state = $state;
 		$this->phoneNumber = $phoneNumber;
 	}
 
 	public function jsonSerialize() {
 		return [
+			'gatewayName' => $this->gatewayName,
 			'state' => $this->state,
 			'phoneNumber' => $this->phoneNumber,
 		];

--- a/lib/Service/Gateway/PlaySMSGateway.php
+++ b/lib/Service/Gateway/PlaySMSGateway.php
@@ -70,4 +70,13 @@ class PlaySMSGateway implements IGateway {
 		}
 	}
 
+	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string {
+		return "SMS";
+	}
 }

--- a/lib/Service/Gateway/PlaySMSGateway.php
+++ b/lib/Service/Gateway/PlaySMSGateway.php
@@ -25,13 +25,13 @@ namespace OCA\TwoFactorGateway\Service\Gateway;
 
 use Exception;
 use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IUser;
 
-class PlaySMSGateway implements ISmsService {
+class PlaySMSGateway implements IGateway {
 
 	/** @var IClient */
 	private $client;

--- a/lib/Service/Gateway/SignalGateway.php
+++ b/lib/Service/Gateway/SignalGateway.php
@@ -72,4 +72,13 @@ class SignalGateway implements IGateway {
 		}
 	}
 
+	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string {
+		return "Signal";
+	}
 }

--- a/lib/Service/Gateway/SignalGateway.php
+++ b/lib/Service/Gateway/SignalGateway.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorGateway\Service\Gateway;
 
 use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCP\Http\Client\IClientService;
 use OCP\ILogger;
 use OCP\IUser;
@@ -33,7 +33,7 @@ use OCP\IUser;
 /**
  * An integration of https://gitlab.com/morph027/signal-web-gateway
  */
-class SignalGateway implements ISmsService {
+class SignalGateway implements IGateway {
 
 	/** @var IClientService */
 	private $clientService;

--- a/lib/Service/Gateway/TelegramGateway.php
+++ b/lib/Service/Gateway/TelegramGateway.php
@@ -26,7 +26,7 @@ namespace OCA\TwoFactorGateway\Service\Gateway;
 
 use Exception;
 use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
@@ -34,7 +34,7 @@ use OCP\IUser;
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
 
-class TelegramGateway implements ISmsService {
+class TelegramGateway implements IGateway {
 
 	/** @var IClient */
 	private $client;

--- a/lib/Service/Gateway/TelegramGateway.php
+++ b/lib/Service/Gateway/TelegramGateway.php
@@ -58,7 +58,7 @@ class TelegramGateway implements IGateway {
 		// TODO: token missing handling
 
 		$api = new Api($token);
-		$chatId = $this->getChatId($user, $api, (int) $idenfier);
+		$chatId = $this->getChatId($user, $api, (int)$idenfier);
 
 		$api->sendMessage([
 			'chat_id' => $chatId,
@@ -89,4 +89,13 @@ class TelegramGateway implements IGateway {
 		return (int)$chatId;
 	}
 
+	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string {
+		return "Telegram";
+	}
 }

--- a/lib/Service/Gateway/TestGateway.php
+++ b/lib/Service/Gateway/TestGateway.php
@@ -24,11 +24,11 @@
 
 namespace OCA\TwoFactorGateway\Service\Gateway;
 
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCP\ILogger;
 use OCP\IUser;
 
-class TestGateway implements ISmsService {
+class TestGateway implements IGateway {
 
 	/** @var ILogger */
 	private $logger;

--- a/lib/Service/Gateway/TestGateway.php
+++ b/lib/Service/Gateway/TestGateway.php
@@ -41,4 +41,13 @@ class TestGateway implements IGateway {
 		$this->logger->info("message to <$idenfier>: $message");
 	}
 
+	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string {
+		return "Test";
+	}
 }

--- a/lib/Service/Gateway/WebSmsGateway.php
+++ b/lib/Service/Gateway/WebSmsGateway.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -70,4 +70,13 @@ class WebSmsGateway implements IGateway {
 		}
 	}
 
+	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string {
+		return "SMS";
+	}
 }

--- a/lib/Service/Gateway/WebSmsGateway.php
+++ b/lib/Service/Gateway/WebSmsGateway.php
@@ -25,13 +25,13 @@ namespace OCA\TwoFactorGateway\Service\Gateway;
 
 use Exception;
 use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IUser;
 
-class WebSmsGateway implements ISmsService {
+class WebSmsGateway implements IGateway {
 
 	/** @var IClient */
 	private $client;

--- a/lib/Service/IGateway.php
+++ b/lib/Service/IGateway.php
@@ -28,6 +28,14 @@ use OCP\IUser;
 interface IGateway {
 
 	/**
+	 * Get a short description of this gateway's name so that users know how
+	 * their messages are delivered, e.g. "Telegram"
+	 *
+	 * @return string
+	 */
+	public function getShortName(): string;
+
+	/**
 	 * @param IUser $user
 	 * @param string $idenfier
 	 * @param string $message

--- a/lib/Service/IGateway.php
+++ b/lib/Service/IGateway.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -25,7 +25,7 @@ namespace OCA\TwoFactorGateway\Service;
 
 use OCP\IUser;
 
-interface ISmsService {
+interface IGateway {
 
 	/**
 	 * @param IUser $user

--- a/lib/Service/SetupService.php
+++ b/lib/Service/SetupService.php
@@ -42,14 +42,14 @@ class SetupService {
 	private $config;
 
 
-	/** @var ISmsService */
+	/** @var IGateway */
 	private $smsService;
 
 	/** @var ISecureRandom */
 	private $random;
 
 	public function __construct(IConfig $config,
-								ISmsService $smsService, ISecureRandom $random) {
+								IGateway $smsService, ISecureRandom $random) {
 		$this->config = $config;
 
 		$this->smsService = $smsService;

--- a/lib/Service/SetupService.php
+++ b/lib/Service/SetupService.php
@@ -61,7 +61,7 @@ class SetupService {
 		$state = $isVerified ? SmsProvider::STATE_ENABLED : SmsProvider::STATE_DISABLED;
 		$verifiedNumber = $this->config->getUserValue($user->getUID(), 'twofactor_gateway', 'phone', null);
 
-		return new State($state, $verifiedNumber);
+		return new State($this->smsService->getShortName(), $state, $verifiedNumber);
 	}
 
 	/**

--- a/tests/Unit/Provider/SmsProviderTest.php
+++ b/tests/Unit/Provider/SmsProviderTest.php
@@ -24,7 +24,7 @@ namespace OCA\TwoFactorGateway\Tests\Unit\Provider;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\TwoFactorGateway\Provider\SmsProvider;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCA\TwoFactorGateway\Service\SetupService;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -35,7 +35,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 
 class SmsProviderTest extends TestCase {
 
-	/** @var ISmsService|PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGateway|PHPUnit_Framework_MockObject_MockObject */
 	private $smsService;
 
 	/** @var SetupService|PHPUnit_Framework_MockObject_MockObject */
@@ -59,7 +59,7 @@ class SmsProviderTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->smsService = $this->createMock(ISmsService::class);
+		$this->smsService = $this->createMock(IGateway::class);
 		$this->setupService = $this->createMock(SetupService::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->random = $this->createMock(ISecureRandom::class);

--- a/tests/Unit/Service/SetupServiceTest.php
+++ b/tests/Unit/Service/SetupServiceTest.php
@@ -27,7 +27,7 @@ use OC\Accounts\AccountManager;
 use OCA\TwoFactorGateway\Exception\IdentifierMissingException;
 use OCA\TwoFactorGateway\Exception\VerificationException;
 use OCA\TwoFactorGateway\Exception\VerificationTransmissionException;
-use OCA\TwoFactorGateway\Service\ISmsService;
+use OCA\TwoFactorGateway\Service\IGateway;
 use OCA\TwoFactorGateway\Service\SetupService;
 use OCP\IConfig;
 use OCP\IUser;
@@ -39,7 +39,7 @@ class SetupServiceTest extends TestCase {
 	/** @var IConfig|PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
-	/** @var ISmsService|PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGateway|PHPUnit_Framework_MockObject_MockObject */
 	private $smsService;
 
 	/** @var ISecureRandom|PHPUnit_Framework_MockObject_MockObject */
@@ -52,7 +52,7 @@ class SetupServiceTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->smsService = $this->createMock(ISmsService::class);
+		$this->smsService = $this->createMock(IGateway::class);
 		$this->random = $this->createMock(ISecureRandom::class);
 
 		$this->setupService = new SetupService($this->config, $this->smsService, $this->random);


### PR DESCRIPTION
Otherwise `SMS` was wrong in many cases (e.g. when using Telegram as gateway).